### PR TITLE
route53 ttl should be set in seconds

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func (p *Provider) createRecord(ctx context.Context, zoneID string, record libdn
 								Value: aws.String(record.Value),
 							},
 						},
-						TTL:  aws.Int64(int64(record.TTL)),
+						TTL:  aws.Int64(int64(record.TTL.Seconds())),
 						Type: aws.String(record.Type),
 					},
 				},


### PR DESCRIPTION
more details in https://github.com/caddy-dns/route53/issues/17