### PR TITLE
Invalid Record TTL

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -46,7 +46,6 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		newRecord.TTL = time.Duration(newRecord.TTL) * time.Second
 		createdRecords = append(createdRecords, newRecord)
 	}
 
@@ -68,7 +67,6 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		deletedRecord.TTL = time.Duration(deletedRecord.TTL) * time.Second
 		deletedRecords = append(deletedRecords, deletedRecord)
 	}
 
@@ -90,7 +88,6 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		if err != nil {
 			return nil, err
 		}
-		updatedRecord.TTL = time.Duration(updatedRecord.TTL) * time.Second
 		updatedRecords = append(updatedRecords, updatedRecord)
 	}
 


### PR DESCRIPTION
The `client` already expresses the `TTL` in seconds, so the provider should not multiply it by `time.Second` again.

See `client.go`
```go
record := libdns.Record{
    Name:  libdns.AbsoluteName(*rrset.Name, zone),
    Value: *rrsetRecord.Value,
    Type:  *rrset.Type,
    TTL:   time.Duration(*rrset.TTL) * time.Second,
}
```

This is an issue because if the caller uses those records to interact with the AWS SDK again, the TTL overflows an int64 `TTL:  aws.Int64(int64(record.TTL.Seconds()))` leading to invalid input errors when applying new changes:

```bash
InvalidInput: 1 validation error detected: Value '-7780919223' at 'changeBatch.changes.1.member.resourceRecordSet.tTL' failed to satisfy constraint: Member must have value greater than or equal to 0
```