### PR TITLE
fix quotes for long txt and spf records

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -87,6 +88,7 @@ func (p *Provider) getRecords(ctx context.Context, zoneID string, zone string) (
 			break
 		}
 	}
+	var re = regexp.MustCompile(`(?m)" "`)
 
 	for _, rrset := range recordSets {
 		for _, rrsetRecord := range rrset.ResourceRecords {
@@ -97,6 +99,8 @@ func (p *Provider) getRecords(ctx context.Context, zoneID string, zone string) (
 			switch rtype {
 			case types.RRTypeTxt, types.RRTypeSpf:
 				var err error
+				value = re.ReplaceAllString(value, "")
+				//fmt.Println(value)
 				value, err = strconv.Unquote(value)
 				if err != nil {
 					return records, fmt.Errorf("Error unquoting TXT/SPF record: %s", err)


### PR DESCRIPTION
This likely isn't the correct way to do this, but I couldn't find any solid examples of how to process chunked TXT records back into a single value.

This basically takes something like 
```
"asdfasdfasdf" "123123123"
```
and turns it into
```
asdfasdfasdf123123123
```