### PR TITLE
feat(cde-2722): allow to not wait for propagation when deleting DNS records

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -58,6 +58,29 @@ type Provider struct {
 	// WaitForPropagation if set to true, it will wait for the record to be
 	// propagated before returning.
 	WaitForPropagation bool `json:"wait_for_propagation,omitempty"`
+
+	// WaitForDeletePropagation enables not to wait for propogation when cleaning challenge records
+	// 0 (default) will use WaitForPropagation's value (for backwards compatibility)
+	// 1 will always wait, 2 will never wait
+	WaitForDeletePropagation waitForDeletePropagationOption `json:"wait_for_delete_propogation,omitempty"`
+}
+
+type waitForDeletePropagationOption int
+
+const (
+	AlwaysWaitForDeletePropagation waitForDeletePropagationOption = 1
+	NeverWaitForDeletePropagation  waitForDeletePropagationOption = 2
+)
+
+func (p *Provider) shouldWaitForDeletePropagation() bool {
+	switch p.WaitForDeletePropagation {
+	case AlwaysWaitForDeletePropagation:
+		return true
+	case NeverWaitForDeletePropagation:
+		return false
+	default:
+		return p.WaitForPropagation
+	}
 }
 
 // GetRecords lists all the records in the zone.

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,59 @@
+package route53
+
+import (
+	"testing"
+)
+
+func TestProvider_shouldWaitForDeletePropagation(t *testing.T) {
+	type fields struct {
+		WaitForPropagation       bool
+		WaitForDeletePropagation waitForDeletePropagationOption
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "backwards compatability - should wait",
+			fields: fields{
+				WaitForPropagation: true,
+			},
+			want: true,
+		},
+		{
+			name: "backwards compatability - should not wait",
+			fields: fields{
+				WaitForPropagation: false,
+			},
+			want: false,
+		},
+		{
+			name: "opposite from WaitForPropagation - should wait",
+			fields: fields{
+				WaitForPropagation:       false,
+				WaitForDeletePropagation: AlwaysWaitForDeletePropagation,
+			},
+			want: true,
+		},
+		{
+			name: "opposite from WaitForPropagation - should wait",
+			fields: fields{
+				WaitForPropagation:       true,
+				WaitForDeletePropagation: NeverWaitForDeletePropagation,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{
+				WaitForPropagation:       tt.fields.WaitForPropagation,
+				WaitForDeletePropagation: tt.fields.WaitForDeletePropagation,
+			}
+			if got := p.shouldWaitForDeletePropagation(); got != tt.want {
+				t.Errorf("Provider.shouldWaitForDeletePropagation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This package is used often for resolving ACME CA Authorities DNS-01 challenges.

In those cases, waiting for propagation of the deletion of the DNS entries created for the challenge is not necessary.

Is backwards compatible.

