### PR TITLE
feat: add option to specify hosted zone ID

### DIFF
--- a/client.go
+++ b/client.go
@@ -201,6 +201,10 @@ func (p *Provider) getRecords(ctx context.Context, zoneID string, _ string) ([]l
 }
 
 func (p *Provider) getZoneID(ctx context.Context, zoneName string) (string, error) {
+	if p.HostedZoneID != "" {
+		return p.HostedZoneID, nil
+	}
+
 	getZoneInput := &r53.ListHostedZonesByNameInput{
 		DNSName:  aws.String(zoneName),
 		MaxItems: aws.Int32(1),

--- a/client.go
+++ b/client.go
@@ -202,7 +202,7 @@ func (p *Provider) getRecords(ctx context.Context, zoneID string, _ string) ([]l
 
 func (p *Provider) getZoneID(ctx context.Context, zoneName string) (string, error) {
 	if p.HostedZoneID != "" {
-		return p.HostedZoneID, nil
+		return "/hostedzone/" + p.HostedZoneID, nil
 	}
 
 	getZoneInput := &r53.ListHostedZonesByNameInput{

--- a/provider.go
+++ b/provider.go
@@ -58,6 +58,12 @@ type Provider struct {
 	// WaitForPropagation if set to true, it will wait for the record to be
 	// propagated before returning.
 	WaitForPropagation bool `json:"wait_for_propagation,omitempty"`
+
+	// HostedZoneID is the ID of the hosted zone to use. If not set, it will
+	// be discovered from the zone name.
+	//
+	// It must be in the format "/hostedzone/Z01111111111111111111".
+	HostedZoneID string `json:"hosted_zone_id,omitempty"`
 }
 
 // GetRecords lists all the records in the zone.

--- a/provider.go
+++ b/provider.go
@@ -62,7 +62,8 @@ type Provider struct {
 	// HostedZoneID is the ID of the hosted zone to use. If not set, it will
 	// be discovered from the zone name.
 	//
-	// It must be in the format "/hostedzone/Z01111111111111111111".
+	// This option should contain only the ID; the "/hostedzone/" prefix
+	// will be added automatically.
 	HostedZoneID string `json:"hosted_zone_id,omitempty"`
 }
 


### PR DESCRIPTION
For cases where the automatic discovery doesn't work (e.g. when we're creating a certificate for `foo.bar.com`, and have a zone for `bar.com` that we can create the challenge records in).