### PR TITLE
fix: use UPSERT instead of CREATE for single-record AppendRecords

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -115,16 +115,11 @@ func (p *Provider) appendRecordSet(
 		return nil, nil
 	}
 
-	// for single records, use the simple create
-	if len(recordGroup) == 1 {
-		newRecord, err := p.createRecord(ctx, zoneID, recordGroup[0], zone)
-		if err != nil {
-			return nil, err
-		}
-		return []libdns.Record{newRecord}, nil
-	}
-
-	// for multiple records, we need to append to existing set if it exists
+	// Retrieve existing records so we can merge and UPSERT.
+	// This is necessary because Route53 treats a ResourceRecordSet as a single
+	// entity — we must include all existing values when updating it. Using CREATE
+	// would fail if the record set already exists (e.g. a stale ACME challenge
+	// TXT record from a previous attempt).
 	existingRecords, err := p.getRecords(ctx, zoneID, zone)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

When `AppendRecords` is called with a single record, it uses the Route53 `CREATE` action via `createRecord()`. This fails with an `InvalidChangeBatch` error if the ResourceRecordSet already exists:

```
Tried to create resource record set [name='_acme-challenge.example.com.', type='TXT'] but it already exists
```

This commonly happens with ACME DNS-01 challenges (e.g. via Caddy) when a `_acme-challenge` TXT record is left over from a previous attempt — for example after a container restart, failed cleanup, or when both the staging and production ACME servers attempt the challenge.

## Fix

Remove the single-record special case in `appendRecordSet()` so all appends use the existing merge+UPSERT path (which was already used for multi-record appends). This correctly handles both new and existing record sets.

The multi-record path:
1. Fetches existing records for the zone
2. Finds any existing values for the same name+type
3. Merges new records with existing ones
4. Uses `UPSERT` to set the combined record set

This is one extra API call (`ListResourceRecordSets`) compared to the previous single-record path, but is correct and idempotent.